### PR TITLE
Allocate buffers more efficiently

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,8 +1,5 @@
 fn main() {
     println!("cargo:rerun-if-changed=src/lib.c");
 
-    cc::Build::new()
-        .file("src/lib.c")
-        .compile("libvsprintf.a");
+    cc::Build::new().file("src/lib.c").compile("libvsprintf.a");
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,21 +3,17 @@
 extern crate libc;
 
 use libc::size_t;
-use std::iter::repeat;
+use std::convert::TryFrom;
 use std::io::Error;
 use std::os::raw::*;
-
-const INITIAL_BUFFER_SIZE: usize = 512;
 
 /// The result of a vsprintf call.
 pub type Result<T> = ::std::result::Result<T, Error>;
 
 /// Prints a format string into a Rust string.
-pub unsafe fn vsprintf<V>(format: *const c_char,
-                          va_list: *mut V) -> Result<String> {
-    vsprintf_raw(format, va_list).map(|bytes| {
-        String::from_utf8(bytes).expect("vsprintf result is not valid utf-8")
-    })
+pub unsafe fn vsprintf<V>(format: *const c_char, va_list: *mut V) -> Result<String> {
+    vsprintf_raw(format, va_list)
+        .map(|bytes| String::from_utf8(bytes).expect("vsprintf result is not valid utf-8"))
 }
 
 /// Return a buffer with the given length, filled with arbitrary data.
@@ -30,52 +26,39 @@ fn uninitd_buffer_of_len(len: usize) -> Vec<u8> {
 
 /// Prints a format string into a list of raw bytes that form
 /// a null-terminated C string.
-pub unsafe fn vsprintf_raw<V>(format: *const c_char,
-                              va_list: *mut V) -> Result<Vec<u8>> {
-    let list_ptr = va_list  as *mut c_void;
+pub unsafe fn vsprintf_raw<V>(format: *const c_char, va_list: *mut V) -> Result<Vec<u8>> {
+    let list_ptr = va_list as *mut c_void;
 
-    let mut buffer = uninitd_buffer_of_len(INITIAL_BUFFER_SIZE);
+    let character_count = vsnprintf_wrapper(std::ptr::null_mut(), 0, format, list_ptr);
 
-    loop {
-        let character_count = vsnprintf_wrapper(
-            buffer.as_mut_ptr(), buffer.len(), format, list_ptr
-        );
-
-        // Check for errors.
-        if character_count == -1 {
-            // C does not require vsprintf to set errno, but POSIX does.
-            //
-            // Default handling will just generate an 'unknown' IO error
-            // if no errno is set.
-            return Err(Error::last_os_error());
-        } else {
-            assert!(character_count >= 0);
-            let character_count = character_count as usize;
-
-            // Check if we had enough room in the buffer to fit everything.
-            // Note that character_count doesn't include the NULL byte, but
-            // neither do we need to reserve space for it since we'll end up
-            // dropping it anyway. (vsnprintf will still print as much as it can,
-            // even if there isn't room for the NULL byte).
-            if character_count > buffer.len() {
-                // Reserve enough space and try again.
-                buffer = uninitd_buffer_of_len(character_count);
-                continue;
-            } else { // We fit everything into the buffer.
-                // Truncate the buffer up until the null terminator.
-                buffer.truncate(character_count);
-                buffer.shrink_to_fit();
-                break;
-            }
-        }
+    // Check for errors.
+    if character_count == -1 {
+        // C does not require vsprintf to set errno, but POSIX does.
+        //
+        // Default handling will just generate an 'unknown' IO error
+        // if no errno is set.
+        return Err(Error::last_os_error());
     }
+
+    // Include space for NULL byte.
+    let mut buffer = uninitd_buffer_of_len(usize::try_from(character_count).unwrap() + 1);
+
+    let final_character_count =
+        vsnprintf_wrapper(buffer.as_mut_ptr(), buffer.len(), format, list_ptr);
+
+    assert_eq!(final_character_count, character_count);
+
+    // Drop null byte
+    assert_eq!(buffer.pop(), Some(0u8));
 
     Ok(buffer)
 }
 
-extern {
-    fn vsnprintf_wrapper(buffer: *mut u8,
-                         size: size_t,
-                         format: *const c_char,
-                         va_list: *mut c_void) -> libc::c_int;
+extern "C" {
+    fn vsnprintf_wrapper(
+        buffer: *mut u8,
+        size: size_t,
+        format: *const c_char,
+        va_list: *mut c_void,
+    ) -> libc::c_int;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 extern crate libc;
 
 use libc::size_t;
-use std::convert::TryFrom;
 use std::io::Error;
 use std::os::raw::*;
 
@@ -16,40 +15,38 @@ pub unsafe fn vsprintf<V>(format: *const c_char, va_list: *mut V) -> Result<Stri
         .map(|bytes| String::from_utf8(bytes).expect("vsprintf result is not valid utf-8"))
 }
 
-/// Return a buffer with the given length, filled with arbitrary data.
-fn uninitd_buffer_of_len(len: usize) -> Vec<u8> {
-    let mut buffer = Vec::with_capacity(len);
-    // SAFETY: Any bit pattern is a valid u8.
-    unsafe { buffer.set_len(len) };
-    buffer
-}
-
 /// Prints a format string into a list of raw bytes that form
 /// a null-terminated C string.
 pub unsafe fn vsprintf_raw<V>(format: *const c_char, va_list: *mut V) -> Result<Vec<u8>> {
     let list_ptr = va_list as *mut c_void;
 
-    let character_count = vsnprintf_wrapper(std::ptr::null_mut(), 0, format, list_ptr);
+    let mut buffer: Vec<u8> = Vec::new();
+    loop {
+        let rv = vsnprintf_wrapper(buffer.as_mut_ptr(), buffer.len(), format, list_ptr);
 
-    // Check for errors.
-    if character_count == -1 {
-        // C does not require vsprintf to set errno, but POSIX does.
-        //
-        // Default handling will just generate an 'unknown' IO error
-        // if no errno is set.
-        return Err(Error::last_os_error());
+        // Check for errors.
+        let character_count = if rv < 0 {
+            // C does not require vsprintf to set errno, but POSIX does.
+            //
+            // Default handling will just generate an 'unknown' IO error
+            // if no errno is set.
+            return Err(Error::last_os_error());
+        } else {
+            rv as usize
+        };
+
+        if character_count >= buffer.len() {
+            let new_len = character_count + 1;
+            buffer.reserve_exact(new_len - buffer.len());
+            // SAFETY: Any bit pattern is a valid u8, and we reserved the space.
+            buffer.set_len(new_len);
+            continue;
+        }
+
+        // Drop NULL byte and any excess capacity.
+        buffer.truncate(character_count);
+        break;
     }
-
-    // Include space for NULL byte.
-    let mut buffer = uninitd_buffer_of_len(usize::try_from(character_count).unwrap() + 1);
-
-    let final_character_count =
-        vsnprintf_wrapper(buffer.as_mut_ptr(), buffer.len(), format, list_ptr);
-
-    assert_eq!(final_character_count, character_count);
-
-    // Drop null byte
-    assert_eq!(buffer.pop(), Some(0u8));
 
     Ok(buffer)
 }


### PR DESCRIPTION
* Allocate buffer with desired capacity instead of appending one byte at
  a time, which can result in repeated re-allocations.
* Don't initialize buffer to zeros when we're going to overwrite the
  contents anyway.

Experimentally, these changes make a very substantial performance
improvement in Debug builds, though little noticeable difference in
Release builds. e.g. in an experiment with my application that uses
this crate for logging, these changes bring total run time down from
8.64s to 2.45s in Debug builds.