### PR TITLE
Support dylib crate-type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ readme = "README.md"
 
 keywords = ["vsprintf", "sprintf", "printf", "va_list", "va_arg"]
 
+[lib]
+crate-type = ["rlib", "dylib"]
+
 [dependencies]
 libc = "0.2"
 

--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,6 @@ fn main() {
 
     cc::Build::new()
         .file("src/lib.c")
-        .compile("libvsprintf.a");
+        .compile("libvsprintf-c.a");
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub unsafe fn vsprintf_raw<V>(format: *const c_char,
     Ok(buffer)
 }
 
-#[link(name = "vsprintf", kind = "static")]
+#[link(name = "vsprintf-c", kind = "static")]
 extern "C" {
     fn vsnprintf_wrapper(buffer: *mut u8,
                          size: size_t,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,8 @@ pub unsafe fn vsprintf_raw<V>(format: *const c_char,
     Ok(buffer)
 }
 
-extern {
+#[link(name = "vsprintf", kind = "static")]
+extern "C" {
     fn vsnprintf_wrapper(buffer: *mut u8,
                          size: size_t,
                          format: *const c_char,


### PR DESCRIPTION
This PR adds support for dylib crate-type.

It statically links the libvsnprintf.a into the dylib. Otherwise we get

```
error: linking with `cc` failed: exit status: 1
  |
  = note:  "cc" "-m64" "/tmp/rustcDJSjdl/symbols.o" "<40 object files omitted>" "-Wl,--as-needed" "-Wl,-Bdynamic" "/home/kxxt/repos/vsprintf/reproducer/target/debug/deps/libvsprintf.so" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/libstd-54c13a3455b13793.so" "-Wl,-Bstatic" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib/{libcompiler_builtins-*}.rlib" "-Wl,-Bdynamic" "-lgcc_s" "-lutil" "-lrt" "-lpthread" "-lm" "-ldl" "-lc" "-B<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/bin/gcc-ld" "-fuse-ld=lld" "-Wl,--eh-frame-hdr" "-Wl,-z,noexecstack" "-L" "/home/kxxt/repos/vsprintf/reproducer/target/debug/build/vsprintf-92262a54da674b7a/out" "-L" "<sysroot>/lib/rustlib/x86_64-unknown-linux-gnu/lib" "-o" "/home/kxxt/repos/vsprintf/reproducer/target/debug/deps/reproducer-d78040fec6c8bb2e" "-Wl,--gc-sections" "-pie" "-Wl,-z,relro,-z,now" "-nodefaultlibs"
  = note: some arguments are omitted. use `--verbose` to show all linker arguments
  = note: rust-lld: error: undefined symbol: vsnprintf_wrapper
          >>> referenced by lib.rs:33 (/home/kxxt/repos/vsprintf/src/lib.rs:33)
          >>>               /home/kxxt/repos/vsprintf/reproducer/target/debug/deps/reproducer-d78040fec6c8bb2e.49ly8begse5ph7ebdnwi8zwi0.rcgu.o:(vsprintf::vsprintf_raw::hf0f8fe4b8ca2844e)
          collect2: error: ld returned 1 exit status
```